### PR TITLE
Do not run NDN checks on A8C proxied requests

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -13,6 +13,7 @@ class New_Device_Notification_VIP_Go {
 	 */
 	function __construct() {
 		add_filter( 'ndn_location', array( $this, 'filter_ndn_location' ) );
+		add_filter( 'ndn_run_for_current_user', array( $this, 'filter_ndn_run_for_current_user' ) );
 	}
 
 	/**
@@ -28,6 +29,22 @@ class New_Device_Notification_VIP_Go {
 		return $instance;
 	}
 
+	/**
+	 * Hooks the `ndn_run_for_current_user` filter in order to filter out NDN checks for
+	 * proxied requests.
+	 *
+	 * `A8C_PROXIED_REQUEST` constant is defined and set to `true` in case the request comes from known internal proxy IP.
+	 *
+	 * @param bool $is_privileged_user True if current user is privileged. False otherwise.
+	 *
+	 * @return bool False if current request is a proxied one.
+	 */
+	public function filter_ndn_run_for_current_user( $is_privileged_user ) {
+		if ( true === defined( 'A8C_PROXIED_REQUEST' ) && true === A8C_PROXIED_REQUEST ) {
+			return false;
+		}
+		return $is_privileged_user;	
+	}
 
 	/**
 	 * Hooks the `ndn_location` filter to supply the location


### PR DESCRIPTION
We should trust and eventually not report on proxied requests coming to the site.

This commit is hooking the `ndn_run_for_current_user` filter and returns `false` (for skipping the check), in case the `A8C_PROXIED_REQUEST` constant is defined and set to `true`. The new filter returns default value (currently determined as `$is_privileged_user = ! is_proxied_automattician() && current_user_can( 'edit_posts' );`) in case the request is not proxied.